### PR TITLE
fix: added missing `decimals` value in FetchAllCryptoDetailsRequest

### DIFF
--- a/docs/sdk/models/shared/cryptodata.md
+++ b/docs/sdk/models/shared/cryptodata.md
@@ -4,7 +4,7 @@
 ## Fields
 
 | Field                                              | Type                                               | Required                                           | Description                                        |
-| -------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
+|----------------------------------------------------|----------------------------------------------------| -------------------------------------------------- |----------------------------------------------------|
 | `blockchains`                                      | *string*[]                                         | :heavy_minus_sign:                                 | The blockchains on which the cryptocurrency exists |
 | `contracts`                                        | *string*[]                                         | :heavy_minus_sign:                                 | The contracts associated with the cryptocurrency   |
 | `id`                                               | *number*                                           | :heavy_minus_sign:                                 | The unique identifier of the cryptocurrency        |
@@ -19,3 +19,4 @@
 | `priceChange30d`                                   | *number*                                           | :heavy_minus_sign:                                 | Price change 30d                                   |
 | `priceChange7d`                                    | *number*                                           | :heavy_minus_sign:                                 | Price change 7d                                    |
 | `symbol`                                           | *string*                                           | :heavy_minus_sign:                                 | The symbol of the cryptocurrency                   |
+| `decimals`                                         | *number*[]                                         | :heavy_minus_sign:                                 | The decimals of the cryptocurrency                 |


### PR DESCRIPTION
A value that's accepted by `Get All Cryptocurrencies` is `decimals`. The response return also the decimals of the asset. I've edited the `cryptodata.md` file so that it reflects the value when mapping the response.